### PR TITLE
feat(core): result pattern

### DIFF
--- a/lib/chore/utils/result.dart
+++ b/lib/chore/utils/result.dart
@@ -1,5 +1,23 @@
 abstract class Result<T> {
   const Result();
+
+  bool get isSuccess => this is Success<T>;
+  bool get isFailure => this is Failure;
+
+  const factory Result.success(T data) = Success;
+  const factory Result.failure(String message, [Cause? cause]) = Failure;
+
+  Success<T>? asSuccessOrNull() {
+    if (!isSuccess) return null;
+
+    return this as Success<T>;
+  }
+
+  Failure<T>? asFailureOrNull() {
+    if (!isFailure) return null;
+
+    return this as Failure<T>;
+  }
 }
 
 class Success<T> extends Result<T> {

--- a/lib/chore/utils/result.dart
+++ b/lib/chore/utils/result.dart
@@ -1,0 +1,29 @@
+abstract class Result<T> {
+  const Result();
+}
+
+class Success<T> extends Result<T> {
+  const Success(this.data);
+
+  final T data;
+}
+
+class Failure<T> extends Result<T> {
+  const Failure(this.message, [this.failCause]);
+
+  final String message;
+  final Cause? failCause;
+
+  @override
+  String toString() => 'Failure{message: $message, failCause: $failCause}';
+}
+
+class Cause {
+  const Cause(this.error, [this.stackTrace]);
+
+  final dynamic error;
+  final StackTrace? stackTrace;
+
+  @override
+  String toString() => 'Cause{error: $error, stackTrace: $stackTrace}';
+}

--- a/lib/chore/utils/result.dart
+++ b/lib/chore/utils/result.dart
@@ -1,3 +1,5 @@
+typedef EmptyResult = Result<EmptyContent>;
+
 abstract class Result<T> {
   const Result();
 
@@ -18,6 +20,8 @@ abstract class Result<T> {
 
     return this as Failure<T>;
   }
+
+  static EmptyResult emptySuccess() => const Success(EmptyContent());
 }
 
 class Success<T> extends Result<T> {
@@ -44,4 +48,8 @@ class Cause {
 
   @override
   String toString() => 'Cause{error: $error, stackTrace: $stackTrace}';
+}
+
+class EmptyContent {
+  const EmptyContent();
 }

--- a/test/chore/utils/result_test.dart
+++ b/test/chore/utils/result_test.dart
@@ -55,4 +55,52 @@ void main() {
       expect(result.asFailureOrNull(), isNull);
     });
   });
+
+  group('Failure', () {
+    test('can be created with a message', () {
+      //Arrange
+      const failure = Failure('Network error');
+
+      //Act & Assert
+      expect(failure.message, 'Network error');
+      expect(failure.failCause, isNull);
+    });
+
+    test('can be created with a message and a Cause', () {
+      //Arrange
+      final cause = Cause('IOException', StackTrace.current);
+
+      //Act
+      final failure = Failure('File operation failed', cause);
+
+      //Assert
+      expect(failure.message, 'File operation failed');
+      expect(failure.failCause, same(cause));
+    });
+
+
+  });
+
+    group('Cause', () {
+    test('can be created with an error', () {
+      //Arrange
+      const cause = Cause('NullPointerException');
+
+      //Act & Assert
+      expect(cause.error, 'NullPointerException');
+      expect(cause.stackTrace, isNull);
+    });
+
+    test('can be created with an error and a StackTrace', () {
+      //Arrange
+      final stackTrace = StackTrace.current;
+
+      //Act
+      final cause = Cause('FormatException', stackTrace);
+
+      //Assert
+      expect(cause.error, 'FormatException');
+      expect(cause.stackTrace, same(stackTrace));
+    });
+  });
 }

--- a/test/chore/utils/result_test.dart
+++ b/test/chore/utils/result_test.dart
@@ -1,0 +1,58 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:peibo_flutter_technical_test/chore/utils/result.dart';
+
+void main() {
+  group('Result', () {
+    test('isSuccess returns true for Success', () {
+      //Arrange
+      final result = const Success(10);
+
+      //Act & Assert
+      expect(result.isSuccess, isTrue);
+      expect(result.isFailure, isFalse);
+    });
+
+    test('isFailure returns true for Failure', () {
+      //Arrange
+      final result = const Failure('Error message');
+
+      //Act & Assert
+      expect(result.isFailure, isTrue);
+      expect(result.isSuccess, isFalse);
+    });
+
+    test('asSuccessOrNull returns Success object when isSuccess is true', () {
+      //Arrange
+      const result = Success(10);
+
+      //Act & Assert
+      expect(result.asSuccessOrNull(), isA<Success<int>>());
+      expect(result.asSuccessOrNull()?.data, 10);
+    });
+
+    test('asSuccessOrNull returns null when isSuccess is false', () {
+      //Arrange
+      const result = Failure('Error message');
+
+      //Act & Assert
+      expect(result.asSuccessOrNull(), isNull);
+    });
+
+    test('asFailureOrNull returns Failure object when isFailure is true', () {
+      //Arrange
+      const result = Failure('Error message');
+
+      //Act & Assert
+      expect(result.asFailureOrNull(), isA<Failure>());
+      expect(result.asFailureOrNull()?.message, 'Error message');
+    });
+
+    test('asFailureOrNull returns null when isFailure is false', () {
+      //Arrange
+      const result = Success(10);
+
+      //Act & Assert
+      expect(result.asFailureOrNull(), isNull);
+    });
+  });
+}

--- a/test/chore/utils/result_test.dart
+++ b/test/chore/utils/result_test.dart
@@ -54,6 +54,16 @@ void main() {
       //Act & Assert
       expect(result.asFailureOrNull(), isNull);
     });
+
+    test('Result.emptySuccess returns a Success with EmptyContent', () {
+      //Arrange
+      final result = Result.emptySuccess();
+
+      //Act & Assert
+      expect(result.isSuccess, isTrue);
+      expect(result, isA<Success<EmptyContent>>());
+      expect(result.asSuccessOrNull()?.data, isA<EmptyContent>());
+    });
   });
 
   group('Failure', () {


### PR DESCRIPTION
This commit introduces the Result<T> pattern to improve error handling and standardize the way success and failure are returned across layers. It replaces exception-based flow with a type-safe and expressive approach, encouraging better separation of concerns and testability.